### PR TITLE
pre-release version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ a file you can modify:
 
 ```console
 $ helm inspect values oci://ghcr.io/brigadecore/badgr \
-    --version v0.1.0 > ~/badgr-values.yaml
+    --version v1.0.0 > ~/badgr-values.yaml
 ```
 
 Edit `~/badgr-values.yaml`, making the following changes:
@@ -85,7 +85,7 @@ install the gateway using the above customizations:
 
 ```console
 $ helm install badgr oci://ghcr.io/brigadecore/badgr \
-    --version v0.1.0 \
+    --version v1.0.0 \
     --create-namespace \
     --namespace badgr \
     --values ~/badgr-values.yaml


### PR DESCRIPTION
This is with intentions of releasing 1.0.0.

This has no dependencies on any other part of Brigade and it's good at doing the one narrowly scoped thing it was designed to do, so I don't see a reason not to release this now.