### PR TITLE
add more linters

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -2,7 +2,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@br
 
 const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
-const goImg = "brigadecore/go-tools:v0.4.0"
+const goImg = "brigadecore/go-tools:v0.5.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.1.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.4.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.5.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.3.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.5.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,20 +6,25 @@ run:
 linters:
   disable-all: true
   enable:
+  - bodyclose
   - depguard
   # - dupl
   - errcheck
+  - exportloopref
+  - forcetypeassert
   - goconst
   - gocyclo
   - gofmt
   - goimports
   - golint
+  - gosec
   - govet
   - lll
   # - maligned
   - misspell
   - nakedret
   - prealloc
+  - unconvert
   - unparam
   - unused
 

--- a/internal/badges/handler_test.go
+++ b/internal/badges/handler_test.go
@@ -31,7 +31,7 @@ func TestHandlerServeHTTP(t *testing.T) {
 	testCases := []struct {
 		name       string
 		handler    *handler
-		assertions func(*httptest.ResponseRecorder)
+		assertions func(*http.Response)
 	}{
 		{
 			name: "warm cache hit",
@@ -42,13 +42,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -73,13 +69,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -104,12 +96,12 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
 				require.Equal(
 					t,
 					badgeURL(NewErrBadge(http.StatusInternalServerError)),
-					rr.Result().Header.Get("Location"),
+					r.Header.Get("Location"),
 				)
 			},
 		},
@@ -135,12 +127,12 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
 				require.Equal(
 					t,
 					badgeURL(NewErrBadge(http.StatusInternalServerError)),
-					rr.Result().Header.Get("Location"),
+					r.Header.Get("Location"),
 				)
 			},
 		},
@@ -166,13 +158,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -197,13 +185,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -228,13 +212,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -259,12 +239,12 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
 				require.Equal(
 					t,
 					badgeURL(NewErrBadge(http.StatusInternalServerError)),
-					rr.Result().Header.Get("Location"),
+					r.Header.Get("Location"),
 				)
 			},
 		},
@@ -290,12 +270,12 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
 				require.Equal(
 					t,
 					badgeURL(NewErrBadge(http.StatusInternalServerError)),
-					rr.Result().Header.Get("Location"),
+					r.Header.Get("Location"),
 				)
 			},
 		},
@@ -321,13 +301,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 		{
@@ -352,13 +328,9 @@ func TestHandlerServeHTTP(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(rr *httptest.ResponseRecorder) {
-				require.Equal(t, http.StatusSeeOther, rr.Result().StatusCode)
-				require.Equal(
-					t,
-					badgeURL(testBadge),
-					rr.Result().Header.Get("Location"),
-				)
+			assertions: func(r *http.Response) {
+				require.Equal(t, http.StatusSeeOther, r.StatusCode)
+				require.Equal(t, badgeURL(testBadge), r.Header.Get("Location"))
 			},
 		},
 	}
@@ -371,7 +343,7 @@ func TestHandlerServeHTTP(t *testing.T) {
 			).Methods(http.MethodGet)
 			rr := httptest.NewRecorder()
 			testRouter.ServeHTTP(rr, testRequest)
-			testCase.assertions(rr)
+			testCase.assertions(rr.Result()) // nolint: bodyclose
 		})
 	}
 }

--- a/internal/badges/redis/cache.go
+++ b/internal/badges/redis/cache.go
@@ -45,6 +45,7 @@ func NewCache(config CacheConfig) badges.Cache {
 	}
 	if config.RedisEnableTLS {
 		redisOpts.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
 			ServerName: config.RedisHost,
 		}
 	}

--- a/internal/badges/redis/cache_test.go
+++ b/internal/badges/redis/cache_test.go
@@ -14,7 +14,8 @@ func TestNewCache(t *testing.T) {
 	const testPrefix = "foo"
 	c := NewCache(
 		CacheConfig{
-			RedisPrefix: testPrefix,
+			RedisPrefix:    testPrefix,
+			RedisEnableTLS: true,
 		},
 	)
 	require.Equal(t, testPrefix, c.(*cache).prefix)


### PR DESCRIPTION
Requires https://github.com/brigadecore/go-tools/pull/16 to be merged and `brigadecore/go-tools:v0.5.0` to be released first, as that image will contain new and updated linters.