### PR TITLE
use ClusterIP as the default service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Edit `~/badgr-values.yaml`, making the following changes:
 
 * `host`: Set this to the host name where you'd like Badgr to be accessible.
 
+* `service.type`: If you plan to enable ingress (advanced), you can leave this
+  as its default -- `ClusterIP`. If you do not plan to enable ingress, you
+  probably will want to change this value to `LoadBalancer`.
+
 Save your changes to `~/badgr-values.yaml` and use the following command to
 install the gateway using the above customizations:
 
@@ -89,13 +93,15 @@ $ helm install badgr oci://ghcr.io/brigadecore/badgr \
     --version v1.0.0 \
     --create-namespace \
     --namespace badgr \
-    --values ~/badgr-values.yaml
+    --values ~/badgr-values.yaml \
+    --wait \
+    --timeout 300s
 ```
 
 ### 2. (RECOMMENDED) Create a DNS Entry
 
-If you installed the gateway without enabling support for an ingress controller,
-this command should help you find the gateway's public IP address:
+If you overrode defaults and set `service.type` to `LoadBalancer`, use this
+command to find the gateway's public IP address:
 
 ```console
 $ kubectl get svc badgr \

--- a/charts/badgr/values.yaml
+++ b/charts/badgr/values.yaml
@@ -44,8 +44,8 @@ tls:
   # key: base 64 encoded key goes here
 
 ingress:
-  ## Whether to enable ingress. By default, this is disabled and Badgr's service
-  ## is of type LoadBalancer instead. Enabling ingress is advanced usage.
+  ## Whether to enable ingress. By default, this is disabled. Enabling ingress
+  ## is advanced usage.
   enabled: false
   ## Optionally use annotations specified by your ingress controller's
   ## documentation to customize the behavior of the ingress resource.
@@ -101,10 +101,15 @@ nodeSelector: {}
 tolerations: []
 
 service:
-  ## If you're going to use an ingress controller, you can change the service
-  ## type to CLusterIP.
-  type: LoadBalancer
-  # nodePort: 31700
+  ## If you're not going to use an ingress controller, you may want to change
+  ## this value to LoadBalancer for production deployments. If running
+  ## locally, you may want to change it to NodePort OR leave it as ClusterIP
+  ## and use `kubectl port-forward` to map a port on the local network
+  ## interface to the service.
+  type: ClusterIP
+  ## Host port the service will be mapped to when service type is either
+  ## NodePort or LoadBalancer. If not specified, Kubernetes chooses.
+  # nodePort:
 
 redis:
   ## Use `helm inspect values bitnami/redis` to see the full set of


### PR DESCRIPTION
This leads to a smoother install experience because we can use `--wait`.