### PR TITLE
upgrade to brigadecore/go-tools:v0.8.0 -- includes go 1.18

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,6 +1,6 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@brigadecore/brigadier"
 
-const goImg = "brigadecore/go-tools:v0.6.0"
+const goImg = "brigadecore/go-tools:v0.8.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.2.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.6.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.6.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.8.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/badgr
 
-go 1.17
+go 1.18
 
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,7 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
-  - bodyclose
+  # - bodyclose # Not yet working with Go 1.18
   - depguard
   # - dupl
   - errcheck
@@ -25,8 +25,8 @@ linters:
   - prealloc
   - revive
   - unconvert
-  - unparam
-  - unused
+  # - unparam # Not yet working with Go 1.18
+  # - unused # Not yet working with Go 1.18
 
 # all available settings for all linters
 linters-settings:

--- a/internal/badges/handler_test.go
+++ b/internal/badges/handler_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func TestNewHandler(t *testing.T) {
-	h := NewHandler(&service{}, &mockCache{})
-	require.NotNil(t, h.(*handler).service)
-	require.NotNil(t, h.(*handler).cache)
+	handler, ok := NewHandler(&service{}, &mockCache{}).(*handler)
+	require.True(t, ok)
+	require.NotNil(t, handler.service)
+	require.NotNil(t, handler.cache)
 }
 
 func TestHandlerServeHTTP(t *testing.T) {

--- a/internal/badges/redis/cache_test.go
+++ b/internal/badges/redis/cache_test.go
@@ -12,16 +12,17 @@ import (
 
 func TestNewCache(t *testing.T) {
 	const testPrefix = "foo"
-	c := NewCache(
+	cache, ok := NewCache(
 		CacheConfig{
 			RedisPrefix:    testPrefix,
 			RedisEnableTLS: true,
 		},
-	)
-	require.Equal(t, testPrefix, c.(*cache).prefix)
-	require.NotNil(t, c.(*cache).redisClient)
-	require.NotNil(t, c.(*cache).getFn)
-	require.NotNil(t, c.(*cache).setFn)
+	).(*cache)
+	require.True(t, ok)
+	require.Equal(t, testPrefix, cache.prefix)
+	require.NotNil(t, cache.redisClient)
+	require.NotNil(t, cache.getFn)
+	require.NotNil(t, cache.setFn)
 }
 
 func TestSet(t *testing.T) {

--- a/internal/badges/service_test.go
+++ b/internal/badges/service_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestNewService(t *testing.T) {
-	s := NewService()
-	require.NotNil(t, s.(*service).listCheckSuitesForRefFn)
+	service, ok := NewService().(*service)
+	require.True(t, ok)
+	require.NotNil(t, service.listCheckSuitesForRefFn)
 }
 
 func TestServiceCheckBadge(t *testing.T) {


### PR DESCRIPTION
Fixes #25 