### PR TITLE
devx: use ctlptl for setting up and tearing down dev clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ publish-chart:
 	'
 
 ################################################################################
-# Targets to facilitate hacking on Badgr.                                      #
+# Targets to facilitate hacking on Badgr                                       #
 ################################################################################
 
 .PHONY: hack-kind-up

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,14 @@ publish-chart:
 # Targets to facilitate hacking on Badgr.                                      #
 ################################################################################
 
+.PHONY: hack-kind-up
+hack-kind-up:
+	ctlptl apply -f hack/kind/cluster.yaml
+
+.PHONY: hack-kind-down
+hack-kind-down:
+	ctlptl delete -f hack/kind/cluster.yaml
+
 .PHONY: hack-build
 hack-build:
 	docker build \

--- a/hack/kind/cluster.yaml
+++ b/hack/kind/cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-badgr-dev-cluster
+product: kind
+registry: brigade-dev-registry


### PR DESCRIPTION
Follow-up to #39 

This adds new make targets for starting and stopping a kind cluster using ctlptl.

#39 should be merged first.