### PR TITLE
upgrade redis to v15.7.6

### DIFF
--- a/charts/badgr/Chart.lock
+++ b/charts/badgr/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.3.2
-digest: sha256:6b65e347a6fb9c55684d9b803e3c6df5fb253583f2468da54ce865221f44888f
-generated: "2021-09-09T13:11:51.779112-04:00"
+  version: 15.7.6
+digest: sha256:038e7dd518500e44096de5b146da876075b250bffe7a35957e501a2f38fe1471
+generated: "2022-06-16T13:04:38.784313-04:00"

--- a/charts/badgr/Chart.yaml
+++ b/charts/badgr/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: cncf-brigade-maintainers@lists.cncf.io
 dependencies:
 - name: redis
-  version: 15.3.2
+  version: 15.7.6
   repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Bitnami has removed Redis v15.3.2 from their chart repository.

v15.7.6 is the latest v15.x release available.

Builds fo this project are broken until this is merged.